### PR TITLE
adding running of xUnit tests project and publishing of results

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-name: Build
+name: CI
 on:
   push:
     branches:
@@ -37,3 +37,13 @@ jobs:
 
     - name: Build Solution
       run: dotnet build -c $env:CONFIGURATION -p:Version=${{ steps.gitversion.outputs.MajorMinorPatch }} -p:PackageVersion=${{ steps.gitversion.outputs.NuGetVersionV2 }} --version-suffix ${{ steps.gitversion.outputs.PreReleaseTag }} src/EncompassApi/EncompassApi.csproj
+
+    - name: Run Tests
+      run: dotnet test src/EncompassApi.xUnitTests/EncompassApi.xUnitTests.csproj --logger "trx;LogFileName=test-results.trx" --results-directory TestResults 
+      continue-on-error: true
+
+    - uses: actions/upload-artifact@v2
+      if: always()
+      with:
+        name: test-results
+        path: 'TestResults/*.trx'

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,7 +1,7 @@
 name: Publish
 on:
   workflow_run:
-    workflows: ["Build"]
+    workflows: ['CI']
     branches:
       - master
     types:

--- a/.github/workflows/test-report.yml
+++ b/.github/workflows/test-report.yml
@@ -1,0 +1,17 @@
+name: 'Test Report'
+on:
+  workflow_run:
+    workflows: ['CI']
+    types:
+      - completed
+
+jobs:
+  report:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: dorny@test-reporter@v1
+        with:
+          artifact: test-results
+          name: xUnit Tests
+          path: '*.trx'
+          reporter: dotnet-trx


### PR DESCRIPTION
WIP for getting unit tests to run during pipeline.

Going to merge to allow for the `workflow_run` logic to be activated for the purposes of testing the visualizing of the test results.