### PR TITLE
Update interface for embedded HttpClientOptions

### DIFF
--- a/src/EncompassApi.FuncApp/Configuration/ConfigHelper.cs
+++ b/src/EncompassApi.FuncApp/Configuration/ConfigHelper.cs
@@ -33,7 +33,7 @@ namespace EncompassApi.FuncApp.Configuration
                 ClientId = GetStringValue("FairwayTokenClient:ClientId"),
                 ClientName = GetStringValue("FairwayTokenClient:ClientName"),
                 ClientSecret = GetStringValue("FairwayTokenClient:ClientSecret"),
-                HostKey = GetStringValue("w9SojZeo2TLvE7aXadnyUJ9aoP1RZJjT8JjG3oE7jDwqCPxYar9C4g=="),
+                HostKey = GetStringValue("FairwayTokenClient:HostKey"),
                 Retry = GetBoolValue("FairwayTokenClient:Retry", true),
                 RetryCount = GetIntValue("FairwayTokenClient:RetryCount", 3),
                 TimeoutInSeconds = GetIntValue("FairwayTokenClient:TimeoutInSeconds", 30)

--- a/src/EncompassApi.FuncApp/Configuration/ConfigHelper.cs
+++ b/src/EncompassApi.FuncApp/Configuration/ConfigHelper.cs
@@ -40,6 +40,18 @@ namespace EncompassApi.FuncApp.Configuration
             };
         }
 
+        public static BaseHttpClientOptions GetEncompassClientOptions()
+        {
+            return new BaseHttpClientOptions
+            {
+                BaseUrl = GetStringValue("EncompassClient:BaseUrl"),
+                ClientName = GetStringValue("EncompassClient:ClientName"),
+                Retry = GetBoolValue("EncompassClient:Retry", true),
+                RetryCount = GetIntValue("EncompassClient:RetryCount", 3),
+                TimeoutInSeconds = GetIntValue("EncompassClient:TimeoutInSeconds", 30)
+            };
+        }
+
         private static string GetStringValue(string name)
         {
             return Environment.GetEnvironmentVariable(name, EnvironmentVariableTarget.Process);

--- a/src/EncompassApi.FuncApp/Startup.cs
+++ b/src/EncompassApi.FuncApp/Startup.cs
@@ -43,7 +43,7 @@ namespace EncompassApi.FuncApp
 
             builder.Services.AddLogging(p => p.AddSerilog(logger));
 
-            AddClientWithEncompassTokenHandlerandInterceptor(builder);
+            AddClientWithFairwayTokenHandlerandInterceptor(builder);
                    
         }
 
@@ -80,7 +80,7 @@ namespace EncompassApi.FuncApp
                     EnableAutoDecompression = true
                 };
                 options.ClientParameters = clientParameters;
-                options.TokenClientOptions = encompassTokenClientOptions;
+                options.EncompassClientOptions = encompassTokenClientOptions;
                 options.EncompassHttpResponseHeaderLoggerOptions = headers;
             },
             config => config.BaseAddress = new Uri(encompassTokenClientOptions.BaseUrl))
@@ -126,6 +126,7 @@ namespace EncompassApi.FuncApp
                 };
                 options.ClientParameters = clientParameters;
                 options.EncompassHttpResponseHeaderLoggerOptions = headers;
+                options.EncompassClientOptions = encompassClientOptions;
             },
             config => config.BaseAddress = new Uri(encompassClientOptions.BaseUrl))
                 .AddEncompassTokenMessageHandler()

--- a/src/EncompassApi/Configuration/HttpClientOptions.cs
+++ b/src/EncompassApi/Configuration/HttpClientOptions.cs
@@ -11,7 +11,7 @@ namespace EncompassApi.Configuration
 
         public ClientParameters ClientParameters { get; set; }
 
-        public BaseHttpClientOptions TokenClientOptions { get; set; }
+        public BaseHttpClientOptions EncompassClientOptions { get; set; }
 
         public EncompassHttpResponseHeaderLoggerOptions EncompassHttpResponseHeaderLoggerOptions { get; set; }
     }

--- a/src/EncompassApi/Configuration/HttpClientOptions.cs
+++ b/src/EncompassApi/Configuration/HttpClientOptions.cs
@@ -11,7 +11,7 @@ namespace EncompassApi.Configuration
 
         public ClientParameters ClientParameters { get; set; }
 
-        public EncompassTokenClientOptions TokenClientOptions { get; set; }
+        public BaseHttpClientOptions TokenClientOptions { get; set; }
 
         public EncompassHttpResponseHeaderLoggerOptions EncompassHttpResponseHeaderLoggerOptions { get; set; }
     }

--- a/src/EncompassApi/Configuration/IHttpClientOptions.cs
+++ b/src/EncompassApi/Configuration/IHttpClientOptions.cs
@@ -5,6 +5,6 @@
         ClientParameters ClientParameters { get; set; }
         HttpClientCompressionHandlerOptions CompressionOptions { get; set; }
         EncompassHttpResponseHeaderLoggerOptions EncompassHttpResponseHeaderLoggerOptions { get; set; }
-        EncompassTokenClientOptions TokenClientOptions { get; set; }
+        BaseHttpClientOptions TokenClientOptions { get; set; }
     }
 }

--- a/src/EncompassApi/Configuration/IHttpClientOptions.cs
+++ b/src/EncompassApi/Configuration/IHttpClientOptions.cs
@@ -5,6 +5,6 @@
         ClientParameters ClientParameters { get; set; }
         HttpClientCompressionHandlerOptions CompressionOptions { get; set; }
         EncompassHttpResponseHeaderLoggerOptions EncompassHttpResponseHeaderLoggerOptions { get; set; }
-        BaseHttpClientOptions TokenClientOptions { get; set; }
+        BaseHttpClientOptions EncompassClientOptions { get; set; }
     }
 }

--- a/src/EncompassApi/Extensions/EncompassHttpClientBuilder.cs
+++ b/src/EncompassApi/Extensions/EncompassHttpClientBuilder.cs
@@ -59,7 +59,7 @@ namespace EncompassApi.Extensions
 
         public EncompassHttpClientBuilder AddEncompassRetryPolicyHandler()
         {
-            var retryPolicy = HttpPolicyExtensions.HandleTransientHttpError().RetryAsync(_options.TokenClientOptions.RetryCount);
+            var retryPolicy = HttpPolicyExtensions.HandleTransientHttpError().RetryAsync(_options.EncompassClientOptions.RetryCount);
             _builder.AddPolicyHandler(retryPolicy);
             return this;
         }
@@ -67,7 +67,7 @@ namespace EncompassApi.Extensions
 
         public EncompassHttpClientBuilder AddEncompassTimeoutPolicyHandler()
         {
-            var timeoutPolicy = Policy.TimeoutAsync<HttpResponseMessage>(_options.TokenClientOptions.TimeoutInSeconds);
+            var timeoutPolicy = Policy.TimeoutAsync<HttpResponseMessage>(_options.EncompassClientOptions.TimeoutInSeconds);
             _builder.AddPolicyHandler(timeoutPolicy);
             return this;
         }


### PR DESCRIPTION
Update interface for embedded tokenclientoptions within HttpClientOptions to have return type BaseHttpClientOptions as it is only used for retry and timeout